### PR TITLE
Bug/0003 alter attachment id does not exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ SUMMERNOTE_CONFIG = {
     # You can completely disable the attachment feature.
     'disable_attachment': False,
 
-    # Set to `True` to return attachment paths in absolute URIs.
-    'attachment_absolute_uri': False,
+    # Set to `False` to return attachment paths in relative URIs.
+    'attachment_absolute_uri': True,
 
     # test_func in summernote upload view. (Allow upload images only when user passes the test)
     # https://docs.djangoproject.com/en/2.2/topics/auth/default/#django.contrib.auth.mixins.UserPassesTestMixin

--- a/django_summernote/apps.py
+++ b/django_summernote/apps.py
@@ -34,7 +34,7 @@ class DjangoSummernoteConfig(AppConfig):
             'attachment_filesize_limit': 1024 * 1024,
             'attachment_require_authentication': False,
             'attachment_model': 'django_summernote.Attachment',
-            'attachment_absolute_uri': False,
+            'attachment_absolute_uri': True,
 
             # additional test_func, for example you want to check if user is in specific group:
             # https://docs.djangoproject.com/en/2.2/topics/auth/default/#django.contrib.auth.mixins.UserPassesTestMixin

--- a/django_summernote/apps.py
+++ b/django_summernote/apps.py
@@ -8,6 +8,7 @@ from django_summernote.utils import (
 class DjangoSummernoteConfig(AppConfig):
     name = 'django_summernote'
     verbose_name = 'Django Summernote'
+    default_auto_field = 'django.db.models.AutoField'
 
     theme = 'bs3'
     config = {}

--- a/django_summernote/models.py
+++ b/django_summernote/models.py
@@ -1,11 +1,12 @@
 from django.db import models
-from django_summernote.utils import get_attachment_storage, get_attachment_upload_to
 
+from django_summernote.utils import get_attachment_storage, get_attachment_upload_to
 
 __all__ = ['AbstractAttachment', 'Attachment', ]
 
 
 class AbstractAttachment(models.Model):
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     name = models.CharField(max_length=255, null=True, blank=True, help_text="Defaults to filename, if left blank")
     file = models.FileField(
         upload_to=get_attachment_upload_to(),

--- a/django_summernote/test_django_summernote.py
+++ b/django_summernote/test_django_summernote.py
@@ -303,7 +303,7 @@ class DjangoSummernoteTest(TestCase):
                 )
                 self.assertTrue(mock_logging.error.called)
         except ImportError:
-            # Without PIL, we cannot check the uploaded attachement has image format or not
+            # Without PIL, we cannot check the uploaded attachment has image format or not
             with open(IMAGE_FILE, 'rb') as fp:
                 response = self.client.post(url, {'files': [fp]})
                 self.assertEqual(response.status_code, 200)

--- a/django_summernote/test_django_summernote.py
+++ b/django_summernote/test_django_summernote.py
@@ -270,6 +270,8 @@ class DjangoSummernoteTest(TestCase):
 
     @patch('django_summernote.views.logger')
     def test_attachment_disable_attachment(self, mock_logging):
+        from django_summernote.widgets import SummernoteWidget
+
         url = reverse('django_summernote-upload_attachment')
         self.summernote_config['disable_attachment'] = True
 
@@ -278,6 +280,8 @@ class DjangoSummernoteTest(TestCase):
             self.assertEqual(response.status_code, 403)
             self.assertDictEqual(response.json(), {"status": "false", "message": "Attachment module is disabled"})
             self.assertTrue(mock_logging.error.called)
+
+        self.assertNotIn('upload_attachment', SummernoteWidget().summernote_settings()['url'])
 
         self.summernote_config['disable_attachment'] = False
 

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -25,9 +25,10 @@ class SummernoteWidgetBase(forms.Textarea):
             'lang': lang,
             'url': {
                 'language': static('summernote/lang/summernote-' + lang + '.min.js'),
-                'upload_attachment': reverse('django_summernote-upload_attachment'),
             },
         })
+        if not get_config().get('disable_attachment', False):
+            summernote_settings['url']['upload_attachment'] = reverse('django_summernote-upload_attachment')
         return summernote_settings
 
     def value_from_datadict(self, data, files, name):


### PR DESCRIPTION
Resolves https://github.com/summernote/django-summernote/issues/492 without explicitly relying on creating new migration file